### PR TITLE
Port extension to GNOME 45

### DIFF
--- a/extension/metadata.json
+++ b/extension/metadata.json
@@ -5,10 +5,8 @@
     "settings-schema": "org.gnome.shell.extensions.rocketbar",
     "gettext-domain": "rocketbar",
     "url": "https://github.com/linux-is-awesome/gnome_extension_rocketbar",
-    "version": 8,
+    "version": 9,
     "shell-version": [
-        "42",
-        "43",
-        "44"
+        "45"
     ]
 }

--- a/extension/prefs.js
+++ b/extension/prefs.js
@@ -1,29 +1,27 @@
-const ExtensionUtils = imports.misc.extensionUtils;
-const Me = ExtensionUtils.getCurrentExtension();
-const { GeneralPage } = Me.imports.settings.generalPage;
-const { CustomizePage } = Me.imports.settings.customizePage;
-const { BehaviorPage } = Me.imports.settings.behaviorPage;
-const { AboutPage } = Me.imports.settings.aboutPage;
+import {ExtensionPreferences} from 'resource:///org/gnome/Shell/Extensions/js/extensions/prefs.js';
 
-function init() {
-    ExtensionUtils.initTranslations();
-}
+import { GeneralPage } from './settings.generalPage.js';
+import { CustomizePage } from './settings.customizePage.js';
+import { BehaviorPage } from './settings.behaviorPage.js';
+import { AboutPage } from './settings.aboutPage.js';
 
-function fillPreferencesWindow(window) {
-    const settings = ExtensionUtils.getSettings();
+export default class RocketBarExtensionPreferences extends ExtensionPreferences {
+    fillPreferencesWindow(window) {
+        const settings = this.getSettings();
 
-    // enable search
-    window.set_search_enabled(true);
+        // enable search
+        window.set_search_enabled(true);
 
-    // resize the window
-    window.set_size_request(
-        window.default_width + 50,
-        window.default_height + 150
-    );
+        // resize the window
+        window.set_size_request(
+            window.default_width + 50,
+            window.default_height + 150
+        );
 
-    // create pages
-    window.add(new GeneralPage(settings));
-    window.add(new CustomizePage(settings));
-    window.add(new BehaviorPage(settings));
-    window.add(new AboutPage());
+        // create pages
+        window.add(new GeneralPage(settings));
+        window.add(new CustomizePage(settings));
+        window.add(new BehaviorPage(settings));
+        window.add(new AboutPage());
+    }
 }

--- a/extension/prefs.js
+++ b/extension/prefs.js
@@ -1,9 +1,9 @@
-import {ExtensionPreferences} from 'resource:///org/gnome/Shell/Extensions/js/extensions/prefs.js';
+import { ExtensionPreferences } from 'resource:///org/gnome/Shell/Extensions/js/extensions/prefs.js';
 
-import { GeneralPage } from './settings.generalPage.js';
-import { CustomizePage } from './settings.customizePage.js';
-import { BehaviorPage } from './settings.behaviorPage.js';
-import { AboutPage } from './settings.aboutPage.js';
+import { GeneralPage } from './settings/generalPage.js';
+import { CustomizePage } from './settings/customizePage.js';
+import { BehaviorPage } from './settings/behaviorPage.js';
+import { AboutPage } from './settings/aboutPage.js';
 
 export default class RocketBarExtensionPreferences extends ExtensionPreferences {
     fillPreferencesWindow(window) {
@@ -22,6 +22,6 @@ export default class RocketBarExtensionPreferences extends ExtensionPreferences 
         window.add(new GeneralPage(settings));
         window.add(new CustomizePage(settings));
         window.add(new BehaviorPage(settings));
-        window.add(new AboutPage());
+        window.add(new AboutPage(this.metadata));
     }
 }

--- a/extension/services/notificationHandler.js
+++ b/extension/services/notificationHandler.js
@@ -2,16 +2,15 @@
 
 //#region imports
 
-const Main = imports.ui.main;
-const { FdoNotificationDaemonSource, GtkNotificationDaemonAppSource } = imports.ui.notificationDaemon;
-const { WindowAttentionSource } = imports.ui.windowAttentionHandler;
+import * as Main from 'resource:///org/gnome/shell/ui/main.js';
+import { FdoNotificationDaemonSource, GtkNotificationDaemonAppSource } from 'resource:///org/gnome/shell/ui/notificationDaemon.js';
+// TODO: fix this import
+// import { WindowAttentionSource } from 'resource:///org/gnome/shell/ui/windowAttentionHandler.js';
 
 // custom modules import
-const ExtensionUtils = imports.misc.extensionUtils;
-const Me = ExtensionUtils.getCurrentExtension();
-const { Timeout } = Me.imports.utils.timeout;
-const { Connections } = Me.imports.utils.connections;
-const { LauncherAPI } = Me.imports.utils.launcherAPI;
+import { Connections } from '../utils/connections.js';
+import { LauncherAPI } from '../utils/launcherAPI.js';
+import { Timeout } from '../utils/timeout.js';
 
 //#endregion imports
 
@@ -250,7 +249,8 @@ class NotificationService {
                 appId = source.app ? source.app.id : null;
             } else if (source instanceof GtkNotificationDaemonAppSource) {
                 appId = source._appId;
-            } else if (source instanceof WindowAttentionSource && this._config.countAttentionSources) {
+            // TODO: fix this
+            } else if (/* source instanceof WindowAttentionSource && */this._config.countAttentionSources) {
                 appId = source._app ? source._app.id : null;
             } else {
                 continue;
@@ -296,7 +296,7 @@ class NotificationService {
     }
 }
 
-var NotificationHandler = class {
+export class NotificationHandler {
 
     // static instance of NotificationService
     static _service = null;

--- a/extension/services/soundVolumeService.js
+++ b/extension/services/soundVolumeService.js
@@ -2,15 +2,15 @@
 
 //#region imports
 
-const { Gio, Gvc, Shell } = imports.gi;
-const Main = imports.ui.main;
-const Volume = imports.ui.status.volume;
+import Gio from 'gi://Gio';
+import Gvc from 'gi://Gvc';
+import Shell from 'gi://Shell';
+import * as Main from 'resource:///org/gnome/shell/ui/main.js';
+import * as Volume from 'resource:///org/gnome/shell/ui/status/volume.js';
 
 // custom modules import
-const ExtensionUtils = imports.misc.extensionUtils;
-const Me = ExtensionUtils.getCurrentExtension();
-const { Connections } = Me.imports.utils.connections;
-const { Timeout } = Me.imports.utils.timeout;
+import { Connections } from '../utils/connections.js';
+import { Timeout } from '../utils/timeout.js';
 
 //#endregion imports
 
@@ -170,7 +170,7 @@ class SoundVolumeControlBase {
 
 //#region system wide control
 
-var SoundVolumeControl = class extends SoundVolumeControlBase {
+export class SoundVolumeControl extends SoundVolumeControlBase {
 
     constructor() {
         super();
@@ -480,7 +480,7 @@ class AppSoundVolumeService {
 
 }
 
-var AppSoundVolumeControl = class extends SoundVolumeControlBase {
+export class AppSoundVolumeControl extends SoundVolumeControlBase {
 
     static _service = null;
 

--- a/extension/settings/aboutPage.js
+++ b/extension/settings/aboutPage.js
@@ -1,36 +1,33 @@
 import GObject from 'gi://GObject';
-const { GObject } = imports.gi;
-const ExtensionUtils = imports.misc.extensionUtils;
-const Me = ExtensionUtils.getCurrentExtension();
-const { SettingsPageTemplate } = Me.imports.settings.pageTemplate;
+import { gettext as _ } from 'resource:///org/gnome/Shell/Extensions/js/extensions/prefs.js';
 
-const _ = imports.misc.extensionUtils.gettext;
+import { SettingsPageTemplate } from './pageTemplate.js';
 
-var AboutPage = GObject.registerClass(
+export const AboutPage = GObject.registerClass(
     class Rocketbar__AboutPage extends SettingsPageTemplate {
 
-        _init() {
+        _init(metadata) {
             super._init({
                 title: _('About'),
                 name: 'AboutPage',
                 icon: 'help-about-symbolic'
             });
 
+            this._metadata = metadata;
+
             this._createLayout();
         }
 
         _createLayout() {
 
-            const metadata = Me.metadata;
-
             this.addGroup(null, [
-                this.createLabel(Me.metadata.name + _(' Version'),  Me.metadata.version + '.0'),
-                this.createLink(_('Release Notes'), metadata.url + '/releases')
+                this.createLabel(this._metadata.name + _(' Version'),  this._metadata.version + '.0'),
+                this.createLink(_('Release Notes'), this._metadata.url + '/releases')
             ]);
 
             this.addGroup(_('Useful Links'), [
-                this.createLink(_('Report an issue'), metadata.url + '/issues'),
-                this.createLink(_('Share your ideas'), metadata.url + '/discussions/categories/ideas')
+                this.createLink(_('Report an issue'), this._metadata.url + '/issues'),
+                this.createLink(_('Share your ideas'), this._metadata.url + '/discussions/categories/ideas')
             ]);
 
             this.addGroup(_('Credits'), [

--- a/extension/settings/aboutPage.js
+++ b/extension/settings/aboutPage.js
@@ -1,3 +1,4 @@
+import GObject from 'gi://GObject';
 const { GObject } = imports.gi;
 const ExtensionUtils = imports.misc.extensionUtils;
 const Me = ExtensionUtils.getCurrentExtension();

--- a/extension/settings/behaviorPage.js
+++ b/extension/settings/behaviorPage.js
@@ -1,11 +1,9 @@
-const { GObject } = imports.gi;
-const ExtensionUtils = imports.misc.extensionUtils;
-const Me = ExtensionUtils.getCurrentExtension();
-const { SettingsPageTemplate } = Me.imports.settings.pageTemplate;
+import GObject from 'gi://GObject';
+import { gettext as _ } from 'resource:///org/gnome/Shell/Extensions/js/extensions/prefs.js';
 
-const _ = imports.misc.extensionUtils.gettext;
+import { SettingsPageTemplate } from './pageTemplate.js';
 
-var BehaviorPage = GObject.registerClass(
+export const BehaviorPage = GObject.registerClass(
     class Rocketbar__BehaviorPage extends SettingsPageTemplate {
 
         _init(settings) {

--- a/extension/settings/customizePage.js
+++ b/extension/settings/customizePage.js
@@ -1,11 +1,9 @@
-const { GObject } = imports.gi;
-const ExtensionUtils = imports.misc.extensionUtils;
-const Me = ExtensionUtils.getCurrentExtension();
-const { SettingsPageTemplate } = Me.imports.settings.pageTemplate;
+import GObject from 'gi://GObject';
+import { gettext as _ } from 'resource:///org/gnome/Shell/Extensions/js/extensions/prefs.js';
 
-const _ = imports.misc.extensionUtils.gettext;
+import { SettingsPageTemplate } from './pageTemplate.js';
 
-var CustomizePage = GObject.registerClass(
+export const CustomizePage = GObject.registerClass(
     class Rocketbar__CustomizePage extends SettingsPageTemplate {
 
         _init(settings) {

--- a/extension/settings/generalPage.js
+++ b/extension/settings/generalPage.js
@@ -1,11 +1,9 @@
-const { GObject } = imports.gi;
-const ExtensionUtils = imports.misc.extensionUtils;
-const Me = ExtensionUtils.getCurrentExtension();
-const { SettingsPageTemplate } = Me.imports.settings.pageTemplate;
+import GObject from 'gi://GObject';
+import { gettext as _ } from 'resource:///org/gnome/Shell/Extensions/js/extensions/prefs.js';
 
-const _ = imports.misc.extensionUtils.gettext;
+import { SettingsPageTemplate } from './pageTemplate.js';
 
-var GeneralPage = GObject.registerClass(
+export const GeneralPage = GObject.registerClass(
     class Rocketbar__GeneralPage extends SettingsPageTemplate {
 
         _init(settings) {

--- a/extension/settings/pageTemplate.js
+++ b/extension/settings/pageTemplate.js
@@ -1,6 +1,10 @@
-const { Adw, Gio, GLib, GObject, Gtk, Gdk } = imports.gi;
+import Adw from 'gi://Adw';
+import Gdk from 'gi://Gdk';
+import GLib from 'gi://GLib';
+import GObject from 'gi://GObject';
+import Gtk from 'gi://Gtk';
 
-var SettingsPageTemplate = GObject.registerClass(
+export const SettingsPageTemplate = GObject.registerClass(
     class Rocketbar__SettingsPageTemplate extends Adw.PreferencesPage {
 
         _init(params) {

--- a/extension/shell/tweaks.js
+++ b/extension/shell/tweaks.js
@@ -2,25 +2,24 @@
 
 //#region imports
 
-const { Clutter, Meta } = imports.gi;
-const Main = imports.ui.main;
-const HotCorner = imports.ui.layout.HotCorner;
-const Keyboard = imports.ui.status.keyboard
-const SwitcherPopup = imports.ui.switcherPopup;
-const { WorkspaceSwitcherPopup } = imports.ui.workspaceSwitcherPopup;
+import Clutter from 'gi://Clutter';
+import Meta from 'gi://Meta';
+import * as Main from 'resource:///org/gnome/shell/ui/main.js';
+import { HotCorner } from 'resource:///org/gnome/shell/ui/layout.js';
+import * as Keyboard from 'resource:///org/gnome/shell/ui/status/keyboard.js';
+import * as SwitcherPopup from 'resource:///org/gnome/shell/ui/switcherPopup.js';
+import { WorkspaceSwitcherPopup } from 'resource:///org/gnome/shell/ui/workspaceSwitcherPopup.js';
 
 // custom modules import
-const ExtensionUtils = imports.misc.extensionUtils;
-const Me = ExtensionUtils.getCurrentExtension();
-const { AppButtonMenu } = Me.imports.ui.appButtonMenu;
-const { SoundVolumeControl } = Me.imports.services.soundVolumeService;
-const { Connections } = Me.imports.utils.connections;
-const { ScrollHandler } = Me.imports.utils.scrollHandler;
-const { Timeout } = Me.imports.utils.timeout;
+import { AppButtonMenu } from '../ui/appButtonMenu.js';
+import { SoundVolumeControl } from '../services/soundVolumeService.js';
+import { Connections } from '../utils/connections.js';
+import { ScrollHandler } from '../utils/scrollHandler.js';
+import { Timeout } from '../utils/timeout.js';
 
 //#endregion imports
 
-var ShellTweaks = class {
+export class ShellTweaks {
 
     constructor(settings) {
 

--- a/extension/ui/appButton.js
+++ b/extension/ui/appButton.js
@@ -17,7 +17,7 @@ import { AppButtonNotificationBadge } from './appButtonNotificationBadge.js';
 import { AppButtonMenu } from './appButtonMenu.js';
 import { AppButtonTooltip } from './appButtonTooltip.js';
 import { DominantColorExtractor } from '../utils/dominantColorExtractor.js';
-import { NotificationHandler } from '../services/notificationHandler.js';
+import { NotificationHandler } from '../services/notificationService.js';
 import { AppSoundVolumeControl } from '../services/soundVolumeService.js';
 import { Connections } from '../utils/connections.js';
 import { ScrollHandler } from '../utils/scrollHandler.js';

--- a/extension/ui/appButton.js
+++ b/extension/ui/appButton.js
@@ -2,25 +2,26 @@
 
 //#region imports
 
-const { Clutter, GObject, Meta, Shell, St } = imports.gi;
-const Main = imports.ui.main;
-const DND = imports.ui.dnd;
-const IconGrid = imports.ui.iconGrid;
+import Clutter from 'gi://Clutter';
+import GObject from 'gi://GObject';
+import Meta from 'gi://Meta';
+import Shell from 'gi://Shell';
+import St from 'gi://St';
+import * as Main from 'resource:///org/gnome/shell/ui/main.js';
+import * as DND from 'resource:///org/gnome/shell/ui/dnd.js';
+import * as IconGrid from 'resource:///org/gnome/shell/ui/iconGrid.js';
 
 // custom modules import
-const ExtensionUtils = imports.misc.extensionUtils;
-const Me = ExtensionUtils.getCurrentExtension();
-const { AppButtonIndicator } = Me.imports.ui.appButtonIndicator;
-const { AppButtonNotificationBadge } = Me.imports.ui.appButtonNotificationBadge;
-const { AppButtonMenu } = Me.imports.ui.appButtonMenu;
-const { AppButtonTooltip } = Me.imports.ui.appButtonTooltip;
-const { DominantColorExtractor } = Me.imports.utils.dominantColorExtractor;
-const { NotificationHandler } = Me.imports.services.notificationService;
-const { AppSoundVolumeControl } = Me.imports.services.soundVolumeService;
-const { Connections } = Me.imports.utils.connections;
-const { ScrollHandler } = Me.imports.utils.scrollHandler;
-const { Timeout } = Me.imports.utils.timeout;
-const { IconProvider } = Me.imports.utils.iconProvider;
+import { AppButtonIndicator } from './appButtonIndicator.js';
+import { AppButtonNotificationBadge } from './appButtonNotificationBadge.js';
+import { AppButtonMenu } from './appButtonMenu.js';
+import { AppButtonTooltip } from './appButtonTooltip.js';
+import { DominantColorExtractor } from '../utils/dominantColorExtractor.js';
+import { NotificationHandler } from '../services/notificationHandler.js';
+import { AppSoundVolumeControl } from '../services/soundVolumeService.js';
+import { Connections } from '../utils/connections.js';
+import { ScrollHandler } from '../utils/scrollHandler.js';
+import { Timeout } from '../utils/timeout.js';
 
 //#endregion imports
 
@@ -162,7 +163,7 @@ class AppButtonConfigOverride {
 
 }
 
-var AppButton = GObject.registerClass(
+export const AppButton = GObject.registerClass(
     class Rocketbar__AppButton extends St.Button {
 
         //#region static
@@ -173,6 +174,52 @@ var AppButton = GObject.registerClass(
         //#endregion static
 
         //#region public methods
+
+        constructor({ app, isFavorite }, settings, iconProvider, stateHandler) {
+
+            // init the button
+            super({
+                name: 'taskbar-appButton',
+                reactive: true,
+                can_focus: true,
+                button_mask: St.ButtonMask.ONE | St.ButtonMask.TWO | St.ButtonMask.THREE,
+                opacity: 0
+            });
+
+            // set public properties
+            this.app = app;
+            this.appId = app?.id;
+            this.isFavorite = isFavorite;
+            this.isActive = false;
+            this.activeWindow = null;
+            this.windows = 0;
+            this.notifications = 0;
+            this.dominantColor = null;
+            this.soundVolumeControl = null;
+            this.configOverride = new AppButtonConfigOverride(this.appId, settings, () => this._handleSettings());
+
+            // set private properties
+            this._settings = settings;
+            this._iconProvider = iconProvider;
+            this._delegate = this;
+            this._firstUpdateIconGeometry = true;
+            this._lastFocusedWindow = null;
+            this._stateHandler = stateHandler;
+
+            this._createLayout();
+
+            this._handleSettings();
+
+            this._createConnections();
+
+            this._createMenu();
+
+            // init notification handler
+            this._notificationHandler = new NotificationHandler(
+                count => this._setNotifications(count),
+                this._settings, this.appId
+            );
+        }
 
         setParent(parent, position, animation) {
 
@@ -233,51 +280,6 @@ var AppButton = GObject.registerClass(
 
         //#region private methods
 
-        _init({ app, isFavorite }, settings, stateHandler) {
-
-            // init the button
-            super._init({
-                name: 'taskbar-appButton',
-                reactive: true,
-                can_focus: true,
-                button_mask: St.ButtonMask.ONE | St.ButtonMask.TWO | St.ButtonMask.THREE,
-                opacity: 0
-            });
-
-            // set public properties
-            this.app = app;
-            this.appId = app?.id;
-            this.isFavorite = isFavorite;
-            this.isActive = false;
-            this.activeWindow = null;
-            this.windows = 0;
-            this.notifications = 0;
-            this.dominantColor = null;
-            this.soundVolumeControl = null;
-            this.configOverride = new AppButtonConfigOverride(this.appId, settings, () => this._handleSettings());
-
-            // set private properties
-            this._settings = settings;
-            this._delegate = this;
-            this._firstUpdateIconGeometry = true;
-            this._lastFocusedWindow = null;
-            this._stateHandler = stateHandler;
-
-            this._createLayout();
-
-            this._handleSettings();
-
-            this._createConnections();
-
-            this._createMenu();
-
-            // init notification handler
-            this._notificationHandler = new NotificationHandler(
-                count => this._setNotifications(count),
-                this._settings, this.appId
-            );
-        }
-
         _createLayout() {
 
             this._appIcon = new St.Bin({
@@ -305,7 +307,7 @@ var AppButton = GObject.registerClass(
         _createMenu() {
             this._createMenuTimeout = Timeout.low(300).run(() => {
 
-                this._menu = new AppButtonMenu(this, this._settings);
+                this._menu = new AppButtonMenu(this, this._settings, this._iconProvider);
 
                 this._connections.add(this._menu, 'open-state-changed', () => this._focus());
             });
@@ -1009,7 +1011,7 @@ var AppButton = GObject.registerClass(
 
             if (!this.dominantColor) {
 
-                this.dominantColor = new DominantColorExtractor(this._appIcon.get_child()).getColor();
+                this.dominantColor = new DominantColorExtractor(this._iconProvider, this._appIcon.get_child()).getColor();
 
                 AppButton._dominantColorCache[this.appId] = this.dominantColor;
             }
@@ -1023,7 +1025,7 @@ var AppButton = GObject.registerClass(
 
             const customIcon = (
                 this._config.customIconPath ?
-                IconProvider.instance().getCustomIcon(this._config.customIconPath) :
+                this._iconProvider.getCustomIcon(this._config.customIconPath) :
                 null
             ); 
 
@@ -1344,7 +1346,7 @@ var AppButton = GObject.registerClass(
                     return;
                 }
 
-                this._tooltip = new AppButtonTooltip(this, this._settings);
+                this._tooltip = new AppButtonTooltip(this, this._settings, this._iconProvider);
                 return;
             }
 

--- a/extension/ui/appButtonIndicator.js
+++ b/extension/ui/appButtonIndicator.js
@@ -2,17 +2,16 @@
 
 //#region imports
 
-const { Clutter, St } = imports.gi;
+import Clutter from 'gi://Clutter';
+import St from 'gi://St';
 
 // custom modules import
-const ExtensionUtils = imports.misc.extensionUtils;
-const Me = ExtensionUtils.getCurrentExtension();
-const { Config } = Me.imports.utils.config;
-const { Connections } = Me.imports.utils.connections;
+import { Config } from '../utils/config.js';
+import { Connections } from '../utils/connections.js';
 
 //#endregion imports
 
-var AppButtonIndicator = class {
+export class AppButtonIndicator {
 
     constructor(appButton, layout, settings) {
 

--- a/extension/ui/appButtonMenu.js
+++ b/extension/ui/appButtonMenu.js
@@ -2,24 +2,21 @@
 
 //#region imports
 
-const Main = imports.ui.main;
-const BoxPointer = imports.ui.boxpointer;
-const { Clutter, St } = imports.gi;
-const { AppMenu } = imports.ui.appMenu;
-const { Slider } = imports.ui.slider;
-const { PopupMenuSection,
-        PopupSeparatorMenuItem,
-        PopupSubMenuMenuItem,
-        PopupBaseMenuItem,
-        Ornament } = imports.ui.popupMenu;
+import Clutter from 'gi://Clutter';
+import St from 'gi://St';
 
-const _ = imports.misc.extensionUtils.gettext;
+import * as Main from 'resource:///org/gnome/shell/ui/main.js';
+import * as BoxPointer from 'resource:///org/gnome/shell/ui/boxpointer.js';
+import { AppMenu } from 'resource:///org/gnome/shell/ui/appMenu.js';
+import { Slider } from 'resource:///org/gnome/shell/ui/slider.js';
+import  { PopupMenuSection,
+    PopupSeparatorMenuItem,
+    PopupSubMenuMenuItem,
+    PopupBaseMenuItem,
+    Ornament } from 'resource:///org/gnome/shell/ui/popupMenu.js';
 
 // custom modules import
-const ExtensionUtils = imports.misc.extensionUtils;
-const Me = ExtensionUtils.getCurrentExtension();
-const { Timeout } = Me.imports.utils.timeout;
-const { IconProvider } = Me.imports.utils.iconProvider;
+import { Timeout } from '../utils/timeout.js';
 
 //#endregion imports
 
@@ -235,12 +232,14 @@ class AppButtonMenuBase extends AppMenu {
 
 }
 
-var AppButtonMenu = class extends AppButtonMenuBase {
+export class AppButtonMenu extends AppButtonMenuBase {
 
     //#region public methods
 
-    constructor(appButton, settings) {
+    constructor(appButton, settings, iconProvider) {
         super(appButton, settings);
+
+        this._iconProvider = iconProvider;
 
         this._addSoundControlSection();
 
@@ -645,7 +644,7 @@ var AppButtonMenu = class extends AppButtonMenuBase {
         return new Promise(resolve => St.Clipboard.get_default().get_text(
             St.ClipboardType.CLIPBOARD,
             (clipboard, iconPath) => resolve(
-                IconProvider.instance().getCustomIcon(iconPath) !== null ?
+                this._iconProvider.getCustomIcon(iconPath) !== null ?
                 iconPath : null
             )
         ));

--- a/extension/ui/appButtonNotificationBadge.js
+++ b/extension/ui/appButtonNotificationBadge.js
@@ -1,9 +1,10 @@
 /* exported AppButtonIndicator */
 
-const { Clutter, St } = imports.gi;
-const IconGrid = imports.ui.iconGrid;
+import Clutter from 'gi://Clutter';
+import St from 'gi://St';
+import * as IconGrid from 'resource:///org/gnome/shell/ui/iconGrid.js';
 
-var AppButtonNotificationBadge = class {
+export class AppButtonNotificationBadge {
 
     constructor(appButton, layout, settings) {
 

--- a/extension/ui/appButtonTooltip.js
+++ b/extension/ui/appButtonTooltip.js
@@ -2,20 +2,18 @@
 
 //#region imports
 
-const { Clutter, St } = imports.gi;
-const Main = imports.ui.main;
+import Clutter from 'gi://Clutter';
+import St from 'gi://St';
+import * as Main from 'resource:///org/gnome/shell/ui/main.js';
 
 // custom modules import
-const ExtensionUtils = imports.misc.extensionUtils;
-const Me = ExtensionUtils.getCurrentExtension();
-const { Timeout } = Me.imports.utils.timeout;
-const { IconProvider } = Me.imports.utils.iconProvider;
+import { Timeout } from '../utils/timeout.js';
 
 //#endregion imports
 
 class TooltipCounter {
 
-    constructor(iconName, minCount) {
+    constructor(icon, minCount) {
 
         this._minCount = minCount || 0;
 
@@ -28,7 +26,7 @@ class TooltipCounter {
 
         this.actor.add_actor(new St.Icon({
             name: 'appButton-tooltip-counter-icon',
-            gicon: IconProvider.instance().getIcon(iconName)
+            gicon: icon
         }));
 
         this._label = new St.Label({
@@ -53,13 +51,14 @@ class TooltipCounter {
     }
 }
 
-var AppButtonTooltip = class {
+export class AppButtonTooltip {
 
     //#region public methods
 
-    constructor(appButton, settings) {
+    constructor(appButton, settings, iconProvider) {
 
         this._appButton = appButton;
+        this._iconProvider = iconProvider;
 
         this._maxWidth = settings.get_int('tooltip-max-width');
 
@@ -134,20 +133,20 @@ var AppButtonTooltip = class {
 
         // create windows counter
 
-        this._windowsCounter = new TooltipCounter('window-symbolic', 2);
+        this._windowsCounter = new TooltipCounter(this._iconProvider.getIcon('window-symbolic'), 2);
 
         this._tooltip.add_actor(this._windowsCounter.actor);
 
         // create notifications counter
 
-        this._notificationsCounter = new TooltipCounter('notification-symbolic', 1);
+        this._notificationsCounter = new TooltipCounter(this._iconProvider.getIcon('notification-symbolic'), 1);
 
         this._tooltip.add_actor(this._notificationsCounter.actor);
 
         // create sound icons
 
-        this._soundOutputVolume = new TooltipCounter('audio-speakers-symbolic');
-        this._soundInputVolume = new TooltipCounter('audio-input-microphone-symbolic');
+        this._soundOutputVolume = new TooltipCounter(this._iconProvider.getIcon('audio-speakers-symbolic'));
+        this._soundInputVolume = new TooltipCounter(this._iconProvider.getIcon('audio-input-microphone-symbolic'));
 
         this._tooltip.add_actor(this._soundOutputVolume.actor);
         this._tooltip.add_actor(this._soundInputVolume.actor);

--- a/extension/ui/notificationCounter.js
+++ b/extension/ui/notificationCounter.js
@@ -9,7 +9,7 @@ import St from 'gi://St';
 import * as Main from 'resource:///org/gnome/shell/ui/main.js';
 
 // custom modules import
-import { NotificationHandler } from '../services/notificationHandler.js';
+import { NotificationHandler } from '../services/notificationService.js';
 import { Timeout } from '../utils/timeout.js';
 import { Connections } from '../utils/connections.js';
 
@@ -95,12 +95,12 @@ class NotificationCounterContainer {
 
         this._connections?.destroy();
 
-        // restore the indicator
-        this._dateMenu?._indicator?._sync();
-
         if (!this._container || !this._dateMenu || !this._dateMenu._clockDisplay) {
             return;
-        }       
+        }
+
+        // restore the indicator
+        this._dateMenu?._indicator?._sync();
 
         // remove children we don't want to destroy from the container
         // before destroying the container itself

--- a/extension/ui/notificationCounter.js
+++ b/extension/ui/notificationCounter.js
@@ -2,15 +2,16 @@
 
 //#region imports
 
-const { GObject, St, Gtk, Clutter } = imports.gi;
-const Main = imports.ui.main;
+import Clutter from 'gi://Clutter';
+import GObject from 'gi://GObject';
+import Gtk from 'gi://Gtk';
+import St from 'gi://St';
+import * as Main from 'resource:///org/gnome/shell/ui/main.js';
 
 // custom modules import
-const ExtensionUtils = imports.misc.extensionUtils;
-const Me = ExtensionUtils.getCurrentExtension();
-const { NotificationHandler } = Me.imports.services.notificationService;
-const { Timeout } = Me.imports.utils.timeout;
-const { Connections } = Me.imports.utils.connections;
+import { NotificationHandler } from '../services/notificationHandler.js';
+import { Timeout } from '../utils/timeout.js';
+import { Connections } from '../utils/connections.js';
 
 //#endregion imports
 
@@ -124,12 +125,12 @@ class NotificationCounterContainer {
 
 }
 
-var NotificationCounter = GObject.registerClass(
+export const NotificationCounter = GObject.registerClass(
     class Rocketbar__NotificationCounter extends St.BoxLayout {
 
-        _init(settings) {
+        constructor(settings) {
 
-            super._init({ name: 'notification-counter' });
+            super({ name: 'notification-counter' });
 
             this._settings = settings;
             this._totalCount = 0;

--- a/extension/utils/config.js
+++ b/extension/utils/config.js
@@ -1,6 +1,6 @@
 /* exported Config */
 
-var Config = class {
+export class Config {
 
     constructor(callback = () => null) {
         this._callback = callback;

--- a/extension/utils/connections.js
+++ b/extension/utils/connections.js
@@ -1,6 +1,6 @@
 /* exported Connections */
 
-var Connections = class {
+export class Connections {
 
     constructor() {
         this._connections = new Map();

--- a/extension/utils/dominantColorExtractor.js
+++ b/extension/utils/dominantColorExtractor.js
@@ -1,10 +1,8 @@
 /* exported DominantColorExtractor */
 
-const { Gio, St, GdkPixbuf } = imports.gi;
-
-const ExtensionUtils = imports.misc.extensionUtils;
-const Me = ExtensionUtils.getCurrentExtension();
-const { IconProvider } = Me.imports.utils.iconProvider;
+import Gio from 'gi://Gio';
+import St from 'gi://St';
+import GdkPixbuf from 'gi://GdkPixbuf';
 
 const DOMINANT_COLOR_SAMPLE_SIZE = 20;
 
@@ -12,9 +10,10 @@ const DOMINANT_COLOR_SAMPLE_SIZE = 20;
 * Credit: Dash to Dock
 * https://github.com/micheleg/dash-to-dock
 */
-var DominantColorExtractor = class {
+export class DominantColorExtractor {
 
-    constructor(icon) {
+    constructor(iconProvider, icon) {
+        this._iconProvider = iconProvider;
         this._icon = icon;
     }
 
@@ -136,7 +135,7 @@ var DominantColorExtractor = class {
         }
 
         // Get the pixel buffer from the icon theme
-        const iconInfo = IconProvider.instance().getIconInfo(
+        const iconInfo = this._iconProvider.getIconInfo(
             iconTexture.get_names()[0],
             DOMINANT_COLOR_SAMPLE_SIZE
         );

--- a/extension/utils/favorites.js
+++ b/extension/utils/favorites.js
@@ -1,17 +1,15 @@
 /* exported Favorites */
 
-const { Shell } = imports.gi;
-const AppFavorites = imports.ui.appFavorites;
-const ExtensionUtils = imports.misc.extensionUtils;
-const Me = ExtensionUtils.getCurrentExtension();
-const { Connections } = Me.imports.utils.connections;
+import Shell from 'gi://Shell';
+import { getAppFavorites } from 'resource:///org/gnome/shell/ui/appFavorites.js';
+import { Connections } from './connections.js';
 
-var Favorites = class {
+export class Favorites {
 
     constructor(callback) {
         this._callback = callback;
         this._apps = null;
-        this._appFavorites = AppFavorites.getAppFavorites();
+        this._appFavorites = getAppFavorites();
         this._connections = new Connections();
         this._connections.add(Shell.AppSystem.get_default(), 'installed-changed', () => this._handleInstalledChanged());
         this._connections.add(this._appFavorites, 'changed', () => this._handleChanged());

--- a/extension/utils/iconProvider.js
+++ b/extension/utils/iconProvider.js
@@ -1,28 +1,13 @@
 /* exported IconProvider */
 
-const { Gio, St, Gtk } = imports.gi;
-const ExtensionUtils = imports.misc.extensionUtils;
+import Gio from 'gi://Gio';
+import St from 'gi://St';
+import Gtk from 'gi://Gtk';
 
-var IconProvider = class {
-
-    static _instance = null;
-    
-    static instance() {
-
-        if (!IconProvider._instance) {
-            IconProvider._instance = new IconProvider();
-        }
-        
-        return IconProvider._instance;
-    }
-
-    static destroy() {
-        IconProvider._instance = null;
-    }
-
-    constructor() {
+export class IconProvider {
+    constructor(extensionPath) {
         this._iconTheme = new Gtk.IconTheme();
-        this._assetsPath = `${ExtensionUtils.getCurrentExtension().path}/assets/icons/`;
+        this._assetsPath = `${extensionPath}/assets/icons/`;
     }
 
     getIcon(iconName, iconSize) {

--- a/extension/utils/launcherAPI.js
+++ b/extension/utils/launcherAPI.js
@@ -1,8 +1,8 @@
 /* exported LauncherAPI */
 
-const Gio = imports.gi.Gio;
+import Gio from 'gi://Gio';
 
-var LauncherAPI = class {
+export class LauncherAPI {
 
     static _instance = null;
 

--- a/extension/utils/positionProvider.js
+++ b/extension/utils/positionProvider.js
@@ -1,8 +1,8 @@
 /* exported PositionProvider */
 
-const Main = imports.ui.main;
+import * as Main from 'resource:///org/gnome/shell/ui/main.js';
 
-var PositionProvider = class {
+export class PositionProvider {
 
     constructor(actor) {
         this._actor = actor;

--- a/extension/utils/scrollHandler.js
+++ b/extension/utils/scrollHandler.js
@@ -1,8 +1,8 @@
 /* exported ScrollHandler */
 
-const { Clutter } = imports.gi;
+import Clutter from 'gi://Clutter';
 
-var ScrollHandler = class {
+export class ScrollHandler {
 
     constructor(actor, callback) {
 

--- a/extension/utils/timeout.js
+++ b/extension/utils/timeout.js
@@ -1,8 +1,9 @@
 /* exported Timeout */
 
-const { GLib, Meta } = imports.gi;
+import GLib from 'gi://GLib';
+import Meta from 'gi://Meta';
 
-var Timeout = class {
+export class Timeout {
 
     static init() {
         return Timeout.idle(400);


### PR DESCRIPTION
**This version is not compatible with GNOME 44 and below. It will need to be uploaded as a separate version on [extensions.gnome.org](https://extensions.gnome.org/) in order to keep the current, pre-45, extension available to those who need it.**

Overview of the changes:
- Changed imports and exports to ESM
- Removed the use of `ExtensionUtils` (removed from GNOME 45). 
- I changed `IconProvider` to no longer be a singleton. It needed to know the path of the extension, and since it couldn't have access to `ExtensionUtils` anymore, I decided to pass the path to its constructor. I decided that therefore it was safer for it to not be a singleton. Unfortunately, it meant having to pass it down: `Extension -> Taskbar -> AppButton -> { AppButtonTooltip, AppButtonMenu }`
- The GJS type `WindowAttentionSource` [is no longer public](https://gitlab.gnome.org/GNOME/gnome-shell/-/blob/45.0/js/ui/windowAttentionHandler.js#L57), so I had to port some logic from the `experimental` branch in order to count notifications correctly.

Resources used for porting:
- [Extensions in GNOME 45](https://blogs.gnome.org/shell-dev/2023/09/02/extensions-in-gnome-45/)
- [Port Extensions to GNOME Shell 45](https://gjs.guide/extensions/upgrading/gnome-shell-45.html)


Fixes #33 